### PR TITLE
imp: atualiza README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Pull Request number that trigger build.
   with:
     evaluation-data: ${{ steps.evaluator.outputs.result }}
     environment: production
-    pr-number: ${{ steps.evaluator.outputs.pr-number }}
+    pr-number: ${{ github.event.inputs.pr_number }}
 ```
 
 ## Learn about GitHub Actions


### PR DESCRIPTION
Devido as alterações na [LEARN-869](https://trybe.atlassian.net/browse/LEARN-869?atlOrigin=eyJpIjoiNjk5MjBkZDIzNTM2NDY5NmExMGJjYmRjN2NlZDAzYjAiLCJwIjoiaiJ9) e como o _workflow_ é disparado via **Github App Selfhosted**, a envvar `GITHUB_ACTOR` não poderá ser usada para pegar o **username** da pessoa estudante. Além disso, o **número** da Pull Request não vem no contexto do evento da _action_. Foi modificado para estes dados serem enviados pelo Github App via _input_. Assim sendo, será necessário modificar os avaliadores para o novo formato.