### PR TITLE
Ajusta o script bash para falhar quando a requisição http não retornar sucesso

### DIFF
--- a/store.sh
+++ b/store.sh
@@ -16,10 +16,21 @@ else
 fi
 
 echo "Sending evaluation information using '$ENVIRONMENT'..."
-curl \
+
+status_code=$(
+  curl \
   -X POST \
   -H "Content-Type: application/json" \
   -d "$PAYLOAD" \
+  --write-out %{http_code} \
+  --silent \
+  --output /dev/null \
   $ENDPOINT
-echo
-echo "Done!"
+)
+
+if [[ "$status_code" == 201 ]]; then
+  echo "Done!"
+else
+  echo "Execution error"
+  exit 1
+fi


### PR DESCRIPTION
**Problema:**
Está acontecendo um falso positivo ao rodar a action na avaliação de projeto das pessoas estudantes quando algum erro de comunicação acontece no backend. Isso da a entender que todas as actions passaram.

**Solução:**
Verificar se o status da requisição é 201 e se não for retornar um `exit 1` para quebrar a action.