### PR TITLE
Verificar arquivos protegidos antes de gravar a nota

### DIFF
--- a/store.sh
+++ b/store.sh
@@ -20,6 +20,20 @@ else
   ENDPOINT="http://localhost:4000/api/v1/deliveries"
 fi
 
+echo -e "${blue}[INFO] Checking changes to protected files"
+
+changes=$(git diff-index --name-only HEAD)
+protected_files=(".github/workflows/main.yml" "trybe.yml" ".trybe/requirements.json")
+
+for file in ${protected_files[@]}
+do
+  if [[ "${changes[*]}" =~ $file ]]; then
+    echo -e "${red}[ERROR] Execution error"
+    echo -e "The file ${file} cannot be modified."
+    exit 1
+  fi
+done
+
 echo -e "${blue}[INFO] Sending evaluation information using →${reset} '$ENVIRONMENT'"
 
 status_code=$(


### PR DESCRIPTION
**Contexto:**
Estamos desvinculando os avaliadores da API Gateway  `github-actions-self-hosted` para utilizar os recursos próprios do Github ao disparar as actions. Um dos papéis do `gitHub-actions-self-hosted` é evitar que a pessoa estudante faça alterações nos arquivos `.github/workflows/main.yml` e `trybe.yml` e cancele o workflow

**Solução:**
Ajustar a action para cancelar o workflow caso os arquivos protegidos sofram alguma alteração.